### PR TITLE
重构buffer pool

### DIFF
--- a/src/observer/storage/common/meta_util.h
+++ b/src/observer/storage/common/meta_util.h
@@ -16,10 +16,10 @@ See the Mulan PSL v2 for more details. */
 
 #include <string>
 
-static const char *TABLE_META_SUFFIX = ".table";
-static const char *TABLE_META_FILE_PATTERN = ".*\\.table$";
-static const char *TABLE_DATA_SUFFIX = ".data";
-static const char *TABLE_INDEX_SUFFIX = ".index";
+static constexpr const char *TABLE_META_SUFFIX = ".table";
+static constexpr const char *TABLE_META_FILE_PATTERN = ".*\\.table$";
+static constexpr const char *TABLE_DATA_SUFFIX = ".data";
+static constexpr const char *TABLE_INDEX_SUFFIX = ".index";
 
 std::string table_meta_file(const char *base_dir, const char *table_name);
 std::string table_data_file(const char *base_dir, const char *table_name);

--- a/src/observer/storage/common/record_manager.cpp
+++ b/src/observer/storage/common/record_manager.cpp
@@ -337,10 +337,7 @@ RC RecordFileHandler::insert_record(const char *data, int record_size, RID *rid)
       return ret;
     }
 
-    //@@@ TODO, remove unpin page here
-    //    if (RC::SUCCESS != disk_buffer_pool_->unpin_page(&page_handle)) {
-    //      LOG_ERROR("Failed to unpin page. file_id:%d", file_id_);
-    //    }
+    disk_buffer_pool_->unpin_page(frame);
   }
 
   // 找到空闲位置

--- a/src/observer/storage/common/record_manager.h
+++ b/src/observer/storage/common/record_manager.h
@@ -15,6 +15,7 @@ See the Mulan PSL v2 for more details. */
 #define __OBSERVER_STORAGE_COMMON_RECORD_MANAGER_H_
 
 #include <sstream>
+#include <limits>
 #include "storage/default/disk_buffer_pool.h"
 
 typedef int32_t SlotNum;

--- a/src/observer/storage/common/table.h
+++ b/src/observer/storage/common/table.h
@@ -30,7 +30,7 @@ class Trx;
 
 class Table {
 public:
-  Table();
+  Table() = default;
   ~Table();
 
   /**
@@ -101,9 +101,8 @@ private:
 private:
   std::string base_dir_;
   TableMeta table_meta_;
-  DiskBufferPool *data_buffer_pool_;  /// 数据文件关联的buffer pool
-  int file_id_;
-  RecordFileHandler *record_handler_;  /// 记录操作
+  DiskBufferPool *data_buffer_pool_ = nullptr;  /// 数据文件关联的buffer pool
+  RecordFileHandler *record_handler_ = nullptr;  /// 记录操作
   std::vector<Index *> indexes_;
 };
 

--- a/src/observer/storage/default/default_handler.cpp
+++ b/src/observer/storage/default/default_handler.cpp
@@ -24,10 +24,20 @@ See the Mulan PSL v2 for more details. */
 #include "storage/common/table.h"
 #include "storage/common/condition_filter.h"
 
+static DefaultHandler *default_handler = nullptr;
+
+void DefaultHandler::set_default(DefaultHandler *handler)
+{
+  if (default_handler != nullptr && handler != nullptr) {
+    LOG_ERROR("default handler is setted");
+    abort();
+  }
+  default_handler = handler;
+}
+
 DefaultHandler &DefaultHandler::get_default()
 {
-  static DefaultHandler handler;
-  return handler;
+  return *default_handler;
 }
 
 DefaultHandler::DefaultHandler()

--- a/src/observer/storage/default/default_handler.h
+++ b/src/observer/storage/default/default_handler.h
@@ -159,6 +159,7 @@ public:
   RC sync();
 
 public:
+  static void set_default(DefaultHandler *handler);
   static DefaultHandler &get_default();
 
 private:

--- a/src/observer/storage/default/disk_buffer_pool.h
+++ b/src/observer/storage/default/disk_buffer_pool.h
@@ -216,7 +216,7 @@ private:
 class BufferPoolManager
 {
 public:
-  BufferPoolManager() = default;
+  BufferPoolManager();
   ~BufferPoolManager();
 
   RC create_file(const char *file_name);
@@ -226,6 +226,7 @@ public:
   RC flush_page(Frame &frame);
 
 public:
+  static void set_instance(BufferPoolManager *bpm);
   static BufferPoolManager &instance();
   
 private:

--- a/src/observer/storage/index/bplus_tree.h
+++ b/src/observer/storage/index/bplus_tree.h
@@ -244,17 +244,17 @@ struct InternalIndexNode : public IndexNode {
 
 class IndexNodeHandler {
 public:
-  IndexNodeHandler(const IndexFileHeader &header, BPPageHandle &page_handle);
+  IndexNodeHandler(const IndexFileHeader &header, Frame *frame);
 
   void init_empty(bool leaf);
 
   bool is_leaf() const;
-  int key_size() const;
-  int value_size() const;
-  int item_size() const;
+  int  key_size() const;
+  int  value_size() const;
+  int  item_size() const;
 
   void increase_size(int n);
-  int size() const;
+  int  size() const;
   void set_parent_page_num(PageNum page_num);
   PageNum parent_page_num() const;
 
@@ -272,7 +272,7 @@ protected:
 
 class LeafIndexNodeHandler : public IndexNodeHandler {
 public: 
-  LeafIndexNodeHandler(const IndexFileHeader &header, BPPageHandle &page_handle);
+  LeafIndexNodeHandler(const IndexFileHeader &header, Frame *frame);
 
   void init_empty();
   void set_next_page(PageNum page_num);
@@ -293,18 +293,18 @@ public:
   void insert(int index, const char *key, const char *value);
   void remove(int index);
   int  remove(const char *key, const KeyComparator &comparator);
-  RC   move_half_to(LeafIndexNodeHandler &other, DiskBufferPool *bp, int file_id);
-  RC   move_first_to_end(LeafIndexNodeHandler &other, DiskBufferPool *disk_buffer_pool, int file_id);
-  RC   move_last_to_front(LeafIndexNodeHandler &other, DiskBufferPool *bp, int file_id);
+  RC   move_half_to(LeafIndexNodeHandler &other, DiskBufferPool *bp);
+  RC   move_first_to_end(LeafIndexNodeHandler &other, DiskBufferPool *disk_buffer_pool);
+  RC   move_last_to_front(LeafIndexNodeHandler &other, DiskBufferPool *bp);
   /**
    * move all items to left page
    */
-  RC move_to(LeafIndexNodeHandler &other, DiskBufferPool *bp, int file_id);
+  RC move_to(LeafIndexNodeHandler &other, DiskBufferPool *bp);
 
   int max_size() const;
   int min_size() const;
 
-  bool validate(const KeyComparator &comparator, DiskBufferPool *bp, int file_id) const;
+  bool validate(const KeyComparator &comparator, DiskBufferPool *bp) const;
 
   friend std::string to_string(const LeafIndexNodeHandler &handler, const KeyPrinter &printer);
 private:
@@ -321,20 +321,20 @@ private:
 
 class InternalIndexNodeHandler : public IndexNodeHandler {
 public:
-  InternalIndexNodeHandler(const IndexFileHeader &header, BPPageHandle &page_handle);
+  InternalIndexNodeHandler(const IndexFileHeader &header, Frame *frame);
 
   void init_empty();
   void create_new_root(PageNum first_page_num, const char *key, PageNum page_num);
 
   void insert(const char *key, PageNum page_num, const KeyComparator &comparator);
-  RC   move_half_to(LeafIndexNodeHandler &other, DiskBufferPool *bp, int file_id);
+  RC   move_half_to(LeafIndexNodeHandler &other, DiskBufferPool *bp);
   char *key_at(int index);
   PageNum value_at(int index);
 
   /**
    * 返回指定子节点在当前节点中的索引
    */
-  int value_index(PageNum page_num);
+  int  value_index(PageNum page_num);
   void set_key_at(int index, const char *key);
   void remove(int index);
 
@@ -349,18 +349,18 @@ public:
   int max_size() const;
   int min_size() const;
 
-  RC move_to(InternalIndexNodeHandler &other, DiskBufferPool *disk_buffer_pool, int file_id);
-  RC move_first_to_end(InternalIndexNodeHandler &other, DiskBufferPool *disk_buffer_pool, int file_id);
-  RC move_last_to_front(InternalIndexNodeHandler &other, DiskBufferPool *bp, int file_id);
-  RC move_half_to(InternalIndexNodeHandler &other, DiskBufferPool *bp, int file_id);
+  RC move_to(InternalIndexNodeHandler &other, DiskBufferPool *disk_buffer_pool);
+  RC move_first_to_end(InternalIndexNodeHandler &other, DiskBufferPool *disk_buffer_pool);
+  RC move_last_to_front(InternalIndexNodeHandler &other, DiskBufferPool *bp);
+  RC move_half_to(InternalIndexNodeHandler &other, DiskBufferPool *bp);
 
-  bool validate(const KeyComparator &comparator, DiskBufferPool *bp, int file_id) const;
+  bool validate(const KeyComparator &comparator, DiskBufferPool *bp) const;
 
   friend std::string to_string(const InternalIndexNodeHandler &handler, const KeyPrinter &printer);
 private:
-  RC copy_from(const char *items, int num, DiskBufferPool *disk_buffer_pool, int file_id);
-  RC append(const char *item, DiskBufferPool *bp, int file_id);
-  RC preappend(const char *item, DiskBufferPool *bp, int file_id);
+  RC copy_from(const char *items, int num, DiskBufferPool *disk_buffer_pool);
+  RC append(const char *item, DiskBufferPool *bp);
+  RC preappend(const char *item, DiskBufferPool *bp);
 
 private:
   char *__item_at(int index) const;
@@ -418,11 +418,6 @@ public:
 
   RC sync();
 
-  const int get_file_id()
-  {
-    return file_id_;
-  }
-
   /**
    * Check whether current B+ tree is invalid or not.
    * return true means current tree is valid, return false means current tree is invalid.
@@ -435,52 +430,48 @@ public:
   RC print_leafs();
 
 private:
-  RC print_leaf(BPPageHandle &page_handle);
-  RC print_internal_node_recursive(BPPageHandle &page_handle);
+  RC print_leaf(Frame *frame);
+  RC print_internal_node_recursive(Frame *frame);
 
   bool validate_node(IndexNode *node);
   bool validate_leaf_link();
-  bool validate_node_recursive(BPPageHandle &page_handle);
+  bool validate_node_recursive(Frame *frame);
 
 protected:
-  RC find_leaf(const char *key, BPPageHandle &page_handle);
-  RC left_most_page(BPPageHandle &page_handle);
-  RC right_most_page(BPPageHandle &page_handle);
+  RC find_leaf(const char *key, Frame *&frame);
+  RC left_most_page(Frame *&frame);
+  RC right_most_page(Frame *&frame);
   RC find_leaf_internal(const std::function<PageNum(InternalIndexNodeHandler &)> &child_page_getter,
-			BPPageHandle &page_handle);
+			Frame *&frame);
 
   RC insert_into_parent(
-      PageNum parent_page, BPPageHandle &left_page_handle, const char *pkey, BPPageHandle &right_page_handle);
-  RC split_leaf(BPPageHandle &leaf_page_handle);
+      PageNum parent_page, Frame *left_frame, const char *pkey, Frame &right_frame);
 
-  RC delete_entry_internal(BPPageHandle &leaf_page_handle, const char *key);
+  RC delete_entry_internal(Frame *leaf_frame, const char *key);
 
-  RC insert_into_new_root(BPPageHandle &left_page_handle, const char *pkey, BPPageHandle &right_page_handle);
+  RC insert_into_new_root(Frame *left_frame, const char *pkey, Frame &right_frame);
 
   template <typename IndexNodeHandlerType>
-  RC split(BPPageHandle &page_handle, BPPageHandle &new_page_handle);
+  RC split(Frame *frame, Frame *&new_frame);
   template <typename IndexNodeHandlerType>
-  RC coalesce_or_redistribute(BPPageHandle &page_handle);
+  RC coalesce_or_redistribute(Frame *frame);
   template <typename IndexNodeHandlerType>
-  RC coalesce(BPPageHandle &neighbor_page_handle, BPPageHandle &page_handle,
-	      BPPageHandle &parent_page_handle, int index);
+  RC coalesce(Frame *neighbor_frame, Frame *frame, Frame *parent_frame, int index);
   template <typename IndexNodeHandlerType>
-  RC redistribute(BPPageHandle &neighbor_page_handle, BPPageHandle &page_handle,
-		  BPPageHandle &parent_page_handle, int index);
+  RC redistribute(Frame *neighbor_frame, Frame *frame, Frame *parent_frame, int index);
 
-  RC insert_entry_into_parent(BPPageHandle &page_handle, BPPageHandle &new_page_handle, const char *key);
-  RC insert_entry_into_leaf_node(BPPageHandle &page_handle, const char *pkey, const RID *rid);
+  RC insert_entry_into_parent(Frame *frame, Frame *new_frame, const char *key);
+  RC insert_entry_into_leaf_node(Frame *frame, const char *pkey, const RID *rid);
   RC update_root_page_num();
   RC create_new_tree(const char *key, const RID *rid);
 
-  RC adjust_root(BPPageHandle &root_page_handle);
+  RC adjust_root(Frame *root_frame);
 
 private:
   char *make_key(const char *user_key, const RID &rid);
   void  free_key(char *key);
 protected:
   DiskBufferPool *disk_buffer_pool_ = nullptr;
-  int file_id_ = -1;
   bool header_dirty_ = false;
   IndexFileHeader file_header_;
 
@@ -519,10 +510,10 @@ private:
 
   /// 使用左右叶子节点和位置来表示扫描的起始位置和终止位置
   /// 起始位置和终止位置都是有效的数据
-  BPPageHandle left_page_handle_;
-  BPPageHandle right_page_handle_;
-  int          iter_index_ = -1;
-  int          end_index_ = -1; // use -1 for end of scan
+  Frame *      left_frame_  = nullptr;
+  Frame *      right_frame_ = nullptr;
+  int          iter_index_  = -1;
+  int          end_index_   = -1; // use -1 for end of scan
 };
 
 #endif  //__OBSERVER_STORAGE_COMMON_INDEX_MANAGER_H_

--- a/src/observer/storage/index/bplus_tree.h
+++ b/src/observer/storage/index/bplus_tree.h
@@ -19,6 +19,7 @@ See the Mulan PSL v2 for more details. */
 
 #include <string.h>
 #include <sstream>
+#include <functional>
 
 #include "storage/common/record_manager.h"
 #include "storage/default/disk_buffer_pool.h"

--- a/src/observer/storage/index/bplus_tree_index.cpp
+++ b/src/observer/storage/index/bplus_tree_index.cpp
@@ -79,10 +79,8 @@ RC BplusTreeIndex::open(const char *file_name, const IndexMeta &index_meta, cons
 RC BplusTreeIndex::close()
 {
   if (inited_) {
-    LOG_INFO("Begin to close index, file_id:%d, index:%s, field:%s",
-        index_handler_.get_file_id(),
-        index_meta_.name(),
-        index_meta_.field());
+    LOG_INFO("Begin to close index, index:%s, field:%s",
+        index_meta_.name(), index_meta_.field());
     index_handler_.close();
     inited_ = false;
   }

--- a/unitest/bp_manager_test.cpp
+++ b/unitest/bp_manager_test.cpp
@@ -15,68 +15,68 @@ See the Mulan PSL v2 for more details. */
 #include "storage/default/disk_buffer_pool.h"
 #include "gtest/gtest.h"
 
-void test_get(BPManager &bp_manager)
+void test_get(BPFrameManager &frame_manager)
 {
-  Frame *frame1 = bp_manager.alloc();
+  Frame *frame1 = frame_manager.alloc();
   ASSERT_NE(frame1, nullptr);
 
-  frame1->file_desc = 0;
-  frame1->page.page_num = 1;
+  frame1->set_file_desc(0);
+  frame1->set_page_num(1);
 
-  ASSERT_EQ(frame1, bp_manager.get(0, 1));
+  ASSERT_EQ(frame1, frame_manager.get(0, 1));
 
-  Frame *frame2 = bp_manager.alloc();
+  Frame *frame2 = frame_manager.alloc();
   ASSERT_NE(frame2, nullptr);
-  frame2->file_desc = 0;
-  frame2->page.page_num = 2;
+  frame2->set_file_desc(0);
+  frame2->set_page_num(2);
 
-  ASSERT_EQ(frame1, bp_manager.get(0, 1));
+  ASSERT_EQ(frame1, frame_manager.get(0, 1));
 
-  Frame *frame3 = bp_manager.alloc();
+  Frame *frame3 = frame_manager.alloc();
   ASSERT_NE(frame3, nullptr);
-  frame3->file_desc = 0;
-  frame3->page.page_num = 3;
+  frame3->set_file_desc(0);
+  frame3->set_page_num(3);
 
-  frame2 = bp_manager.get(0, 2);
+  frame2 = frame_manager.get(0, 2);
   ASSERT_NE(frame2, nullptr);
 
-  Frame *frame4 = bp_manager.alloc();
-  frame4->file_desc = 0;
-  frame4->page.page_num = 4;
+  Frame *frame4 = frame_manager.alloc();
+  frame4->set_file_desc(0);
+  frame4->set_page_num(4);
 
-  bp_manager.free(frame1);
-  frame1 = bp_manager.get(0, 1);
+  frame_manager.free(frame1);
+  frame1 = frame_manager.get(0, 1);
   ASSERT_EQ(frame1, nullptr);
 
-  ASSERT_EQ(frame3, bp_manager.get(0, 3));
+  ASSERT_EQ(frame3, frame_manager.get(0, 3));
 
-  ASSERT_EQ(frame4, bp_manager.get(0, 4));
+  ASSERT_EQ(frame4, frame_manager.get(0, 4));
 
-  bp_manager.free(frame2);
-  bp_manager.free(frame3);
-  bp_manager.free(frame4);
+  frame_manager.free(frame2);
+  frame_manager.free(frame3);
+  frame_manager.free(frame4);
 
-  ASSERT_EQ(nullptr, bp_manager.get(0, 2));
-  ASSERT_EQ(nullptr, bp_manager.get(0, 3));
-  ASSERT_EQ(nullptr, bp_manager.get(0, 4));
+  ASSERT_EQ(nullptr, frame_manager.get(0, 2));
+  ASSERT_EQ(nullptr, frame_manager.get(0, 3));
+  ASSERT_EQ(nullptr, frame_manager.get(0, 4));
 }
 
-void test_alloc(BPManager &bp_manager)
+void test_alloc(BPFrameManager &frame_manager)
 {
-  int size = bp_manager.get_size();
+  int size = frame_manager.get_size();
 
   std::list<Frame *> used_list;
 
   for (int i = 0; i < size; i++) {
-    Frame *item = bp_manager.alloc();
+    Frame *item = frame_manager.alloc();
     ASSERT_NE(item, nullptr);
     used_list.push_back(item);
   }
 
-  ASSERT_EQ(used_list.size(), bp_manager.get_used_num());
+  ASSERT_EQ(used_list.size(), frame_manager.get_used_num());
 
   for (int i = 0; i < size; i++) {
-    Frame *item = bp_manager.alloc();
+    Frame *item = frame_manager.alloc();
 
     ASSERT_EQ(item, nullptr);
   }
@@ -86,26 +86,26 @@ void test_alloc(BPManager &bp_manager)
       Frame *item = used_list.front();
       used_list.pop_front();
 
-      bp_manager.free(item);
+      frame_manager.free(item);
     } else {
-      Frame *item = bp_manager.alloc();
+      Frame *item = frame_manager.alloc();
       used_list.push_back(item);
     }
 
-    ASSERT_EQ(used_list.size(), bp_manager.get_used_num());
+    ASSERT_EQ(used_list.size(), frame_manager.get_used_num());
   }
 }
 
-TEST(test_bp_manager, test_bp_manager_simple_lru)
+TEST(test_frame_manager, test_frame_manager_simple_lru)
 {
-  BPManager bp_manager("Test");
-  bp_manager.init(false, 2);
+  BPFrameManager frame_manager("Test");
+  frame_manager.init(false, 2);
 
-  test_get(bp_manager);
+  test_get(frame_manager);
 
-  test_alloc(bp_manager);
+  test_alloc(frame_manager);
 
-  bp_manager.cleanup();
+  frame_manager.cleanup();
 }
 
 int main(int argc, char **argv)

--- a/unitest/bplus_tree_test.cpp
+++ b/unitest/bplus_tree_test.cpp
@@ -321,20 +321,11 @@ TEST(test_bplus_tree, test_leaf_index_node_handle)
   index_file_header.attr_type = INTS;
 
   Frame frame;
-  frame.dirty = false;
-  frame.pin_count = 0;
-  frame.acc_time = 0;
-  frame.file_desc = 0;
-  frame.page.page_num = 100;
-
-  BPPageHandle page_handle;
-  page_handle.open = true;
-  page_handle.frame = &frame;
 
   KeyComparator key_comparator;
   key_comparator.init(INTS, 4);
 
-  LeafIndexNodeHandler leaf_node(index_file_header, page_handle);
+  LeafIndexNodeHandler leaf_node(index_file_header, &frame);
   leaf_node.init_empty();
   ASSERT_EQ(0, leaf_node.size());
 
@@ -389,20 +380,11 @@ TEST(test_bplus_tree, test_internal_index_node_handle)
   index_file_header.attr_type = INTS;
 
   Frame frame;
-  frame.dirty = false;
-  frame.pin_count = 0;
-  frame.acc_time = 0;
-  frame.file_desc = 0;
-  frame.page.page_num = 100;
-
-  BPPageHandle page_handle;
-  page_handle.open = true;
-  page_handle.frame = &frame;
 
   KeyComparator key_comparator;
   key_comparator.init(INTS, 4);
 
-  InternalIndexNodeHandler internal_node(index_file_header, page_handle);
+  InternalIndexNodeHandler internal_node(index_file_header, &frame);
   internal_node.init_empty();
   ASSERT_EQ(0, internal_node.size());
 
@@ -479,8 +461,6 @@ TEST(test_bplus_tree, test_internal_index_node_handle)
 TEST(test_bplus_tree, test_scanner)
 {
   LoggerFactory::init_default("test.log");
-
-  DiskBufferPool::set_pool_num(POOL_NUM);
 
   const char *index_name = "scanner.btree";
   ::remove(index_name);
@@ -689,10 +669,7 @@ TEST(test_bplus_tree, test_scanner)
 
 TEST(test_bplus_tree, test_bplus_tree_insert)
 {
-
   LoggerFactory::init_default("test.log");
-  // set the disk buffer pool's number to make it is easy to test
-  DiskBufferPool::set_pool_num(POOL_NUM);
 
   ::remove(index_name);
   handler = new BplusTreeHandler();


### PR DESCRIPTION
重构disk buffer pool：
新增BufferPoolManager，管理所有的DiskBufferPool；
原有DiskBufferPool只处理一个文件，取消其中file_id的概念；
删除BPPageHandle，直接使用Frame；
BPManager更名BPFrameManager；
BPFileSubHeader改为BPFileHeader并直接放在DiskBufferPool中