### PR TITLE
print prompt in client on platform without readline

### DIFF
--- a/deps/common/lang/defer.h
+++ b/deps/common/lang/defer.h
@@ -26,7 +26,9 @@ public:
 
   ~DeferHelper()
   {
-    defer_();
+    if (defer_) {
+      defer_();
+    }
   }
 
 private:
@@ -35,8 +37,5 @@ private:
 
 } // namespace common
 
-#define AA(B, C) B##C
-#define BB(B, C) AA(B,C)
-#define DEFER(callback) common::DeferHelper BB(defer_helper_, __LINE__)(callback)
-#undef AA
-#undef BB
+#define DERFER_NAME(suffix) defer_helper_##suffix
+#define DEFER(callback) common::DeferHelper DERFER_NAME(__LINE__)(callback)

--- a/src/obclient/client.cpp
+++ b/src/obclient/client.cpp
@@ -51,6 +51,7 @@ char *my_readline(const char *prompt)
     fprintf(stderr, "failed to alloc line buffer");
     return nullptr;
   }
+  fprintf(stdout, prompt);
   char *s = fgets(buffer, MAX_MEM_BUFFER_SIZE, stdin);
   if (nullptr == s) {
     fprintf(stderr, "failed to read message from console");


### PR DESCRIPTION
1. 修正defer的编译错误；
2. 没有readline的环境上输出prompt

fix https://github.com/oceanbase/miniob/issues/38