### PR TITLE
add a psql exit cmd for miniob

### DIFF
--- a/src/obclient/client.cpp
+++ b/src/obclient/client.cpp
@@ -69,7 +69,7 @@ char *my_readline(const char *prompt)
 bool is_exit_command(const char *cmd) {
   return 0 == strncasecmp("exit", cmd, 4) ||
          0 == strncasecmp("bye", cmd, 3) ||
-	 0 == strncasecmp("\\q", cmd, 2) ;
+         0 == strncasecmp("\\q", cmd, 2) ;
 }
 
 int init_unix_sock(const char *unix_sock_path)

--- a/src/obclient/client.cpp
+++ b/src/obclient/client.cpp
@@ -62,9 +62,14 @@ char *my_readline(const char *prompt)
 }
 #endif // USE_READLINE
 
+/* this function config a exit-cmd list, strncasecmp func truncate the command from terminal according to the number,
+   'strncasecmp("exit", cmd, 4)' means that obclient read command string from terminal, truncate it to 4 chars from 
+   the beginning, then compare the result with 'exit', if they match, exit the obclient.
+*/
 bool is_exit_command(const char *cmd) {
   return 0 == strncasecmp("exit", cmd, 4) ||
-         0 == strncasecmp("bye", cmd, 3);
+         0 == strncasecmp("bye", cmd, 3) ||
+	 0 == strncasecmp("\\q", cmd, 2) ;
 }
 
 int init_unix_sock(const char *unix_sock_path)


### PR DESCRIPTION
This pr try to add a psql (postgresql cmd tool) exit cmd, just a try. In psql, exit cmd tools by using '\q'.

这个pr我想尝试增加一个pgsql命令行工具psql里的退出命令，在psql里，使用\q推出工具。