### PR TITLE
fixed heap-buffer-overflow

### DIFF
--- a/deps/common/io/io.cpp
+++ b/deps/common/io/io.cpp
@@ -72,6 +72,8 @@ int readFromFile(const std::string &fileName, char *&outputData, size_t &fileSiz
 
   fclose(file);
 
+  data = (char *)lrealloc(data, readSize + 1);
+  data[readSize] = '\0';
   outputData = data;
   fileSize = readSize;
   return 0;

--- a/unitest/pidfile_test.cpp
+++ b/unitest/pidfile_test.cpp
@@ -30,14 +30,15 @@ int main()
 
   std::string pidFile = getPidPath();
 
-  char buf[1024] = {0};
-  char *p = buf;
+  char *p = NULL;
   size_t size = 0;
   readFromFile(pidFile, p, size);
 
   std::string temp(p);
   long long target = 0;
   str_to_val(temp, target);
+
+  free(p);
 
   EXPECT_EQ(pid, target);
 }


### PR DESCRIPTION
配置ASAN过程中`make -j8`报heap buffer overflow
排查原因是用char* 构造string，会调用strlen计算char *对应字符串的长度，原字符串是动态通过realloc分配的内存，对C风格字符串的末尾位'\0'未分配内存或未初始化。
![image](https://user-images.githubusercontent.com/59607623/198321892-c317541c-acc0-4288-bd09-4a7812973fd9.png)
附一段重现代码
``` cpp
#include <cstddef>
#include <cstdlib>
#include <iostream>

using namespace std;

// g++ main.cpp -g -fsanitize=address -o main

void foo(char *&str) {
  char *s = NULL;
  size_t len = 9;
  for (int i = 0; i < len; i++) {
    s = (char *)realloc(s, i + 1);
    s[i] = '0' + i;
  }
  // s = (char *)realloc(s, len + 1);
  // s[len] = '\0';
  str = s;
}

int main() {
  char p[16] = {'\0'};
  char *str = p;
  cout << "before call foo: address of str = " << reinterpret_cast<void *>(str)
       << endl;
  foo(str);
  string s(str);
  cout << " after call foo: address of str = " << reinterpret_cast<void *>(str)
       << endl;
  cout << s << endl;
  free(str);
  return 0;
}

```