### PR TITLE
remove cmake_link_directories in client/cmake

### DIFF
--- a/src/obclient/CMakeLists.txt
+++ b/src/obclient/CMakeLists.txt
@@ -8,8 +8,6 @@ TARGET_INCLUDE_DIRECTORIES(obclient PRIVATE . ${PROJECT_SOURCE_DIR}/../deps /usr
 # 父cmake 设置的include_directories 和link_directories并不传导到子cmake里面
 #INCLUDE_DIRECTORIES(BEFORE ${CMAKE_INSTALL_PREFIX}/include)
 
-TARGET_LINK_DIRECTORIES(obclient PRIVATE /usr/local/lib ${PROJECT_BINARY_DIR}/../../lib)
-
 # stdio.h 必须放在readline/readline.h 前面，因为readline头文件不能直接单独编译
 CHECK_INCLUDE_FILES("stdio.h;readline/readline.h" HAVE_READLINE_HEADER)
 


### PR DESCRIPTION
### What problem were solved in this pull request?

Issue Number: close #61 

Problem:
cmake 3.10 版本不支持 cmake_link_directories 命令，而且miniob也不需要

### What is changed and how it works?
将 cmake_link_directories 相关代码删除，可以正常编译

### Other information
