### PR TITLE
Fix problem that record may overflow the page

### DIFF
--- a/src/observer/storage/record/record_manager.cpp
+++ b/src/observer/storage/record/record_manager.cpp
@@ -19,6 +19,8 @@ See the Mulan PSL v2 for more details. */
 
 using namespace common;
 
+static constexpr int PAGE_HEADER_SIZE = (sizeof(PageHeader));
+
 /**
  * @brief 8字节对齐
  * 注: ceiling(a / b) = floor((a + b - 1) / b)
@@ -148,7 +150,7 @@ RC RecordPageHandler::init_empty_page(DiskBufferPool &buffer_pool, PageNum page_
   page_header_->first_record_offset = align8(PAGE_HEADER_SIZE + page_bitmap_size(page_header_->record_capacity));
   this->fix_record_capacity();
   ASSERT(page_header_->first_record_offset + 
-         page_header_->record_capacity * page_header_->record_size, "Record overflow the page size");
+         page_header_->record_capacity * page_header_->record_size <= BP_PAGE_DATA_SIZE, "Record overflow the page size");
 
   bitmap_ = frame_->data() + PAGE_HEADER_SIZE;
   memset(bitmap_, 0, page_bitmap_size(page_header_->record_capacity));

--- a/src/observer/storage/record/record_manager.h
+++ b/src/observer/storage/record/record_manager.h
@@ -26,8 +26,6 @@ class RecordPageHandler;
 class Trx;
 class Table;
 
-#define PAGE_HEADER_SIZE     (sizeof(PageHeader))
-
 /**
  * @brief 这里负责管理在一个文件上表记录(行)的组织/管理
  * @defgroup RecordManager


### PR DESCRIPTION
### What problem were solved in this pull request?

Issue Number: close #226

Problem:
记录管理部分中page_header_中record_capacity初始化有误，需要进行修正
由于record_capacity的计算并没有考虑8字节对齐，计算的是不对齐时页面下容纳的最大记录量。
但第一条记录偏移量first_record_offset需要8字节对齐，使得最后一条记录的数据可能会溢出页面。
### What is changed and how it works?
如果溢出页面，则减少record_capacity数值
同时去掉了部分冗余或含义不清的函数，修改了上取整的计算表达式
完善了记录管理模块成员函数的注释
