### PR TITLE
fix: add missing header files

### DIFF
--- a/src/observer/storage/persist/persist.h
+++ b/src/observer/storage/persist/persist.h
@@ -16,6 +16,7 @@ See the Mulan PSL v2 for more details. */
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
my gcc version:

```text
使用内建 specs。COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/13.2.1/lto-wrapper
目标：x86_64-pc-linux-gnu
配置为：/build/gcc/src/gcc/configure --enable-languages=ada,c,c++,d,fortran,go,lto,objc,obj-c++ --enable-bootstrap --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://bugs.archlinux.org/ --with-build-config=bootstrap-lto --with-linker-hash-style=gnu --with-system-zlib --enable-__cxa_atexit --enable-cet=auto --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-libstdcxx-backtrace --enable-link-serialization=1 --enable-linker-build-id --enable-lto --enable-multilib --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-werror
线程模型：posix
支持的 LTO 压缩算法：zlib zstd
gcc 版本 13.2.1 20230801 (GCC)
```

build log:
```log
[ 69%] Building CXX object src/observer/CMakeFiles/observer_static.dir/storage/trx/trx.cpp.o
In file included from /home/yunshu/Studio/GitHub/miniob/src/observer/storage/persist/persist.cpp:18:
/home/yunshu/Studio/GitHub/miniob/src/observer/storage/persist/persist.h:48:15: 错误：‘uint64_t’未声明
   48 |   RC write_at(uint64_t offset, int size, const char *data, int64_t *out_size = nullptr);
      |               ^~~~~~~~
/home/yunshu/Studio/GitHub/miniob/src/observer/storage/persist/persist.h:57:14: 错误：‘uint64_t’未声明
   57 |   RC read_at(uint64_t offset, int size, char *data, int64_t *out_size = nullptr);
      |              ^~~~~~~~
/home/yunshu/Studio/GitHub/miniob/src/observer/storage/persist/persist.h:60:11: 错误：‘uint64_t’未声明
   60 |   RC seek(uint64_t offset);
      |           ^~~~~~~~
/home/yunshu/Studio/GitHub/miniob/src/observer/storage/persist/persist.cpp:161:4: 错误：no declaration matches ‘RC PersistHandler::write_at(uint64_t, int, const char*, int64_t*)’
  161 | RC PersistHandler::write_at(uint64_t offset, int size, const char *data, int64_t *out_size)
      |    ^~~~~~~~~~~~~~
/home/yunshu/Studio/GitHub/miniob/src/observer/storage/persist/persist.h:48:6: 附注：备选是： ‘RC PersistHandler::write_at(int, int, const char*, int64_t*)’
   48 |   RC write_at(uint64_t offset, int size, const char *data, int64_t *out_size = nullptr);
      |      ^~~~~~~~
/home/yunshu/Studio/GitHub/miniob/src/observer/storage/persist/persist.h:26:7: 附注：‘class PersistHandler’ defined here
   26 | class PersistHandler
      |       ^~~~~~~~~~~~~~
/home/yunshu/Studio/GitHub/miniob/src/observer/storage/persist/persist.cpp:254:4: 错误：no declaration matches ‘RC PersistHandler::read_at(uint64_t, int, char*, int64_t*)’
  254 | RC PersistHandler::read_at(uint64_t offset, int size, char *data, int64_t *out_size)
      |    ^~~~~~~~~~~~~~
/home/yunshu/Studio/GitHub/miniob/src/observer/storage/persist/persist.h:57:6: 附注：备选是： ‘RC PersistHandler::read_at(int, int, char*, int64_t*)’
   57 |   RC read_at(uint64_t offset, int size, char *data, int64_t *out_size = nullptr);
      |      ^~~~~~~
/home/yunshu/Studio/GitHub/miniob/src/observer/storage/persist/persist.h:26:7: 附注：‘class PersistHandler’ defined here
   26 | class PersistHandler
      |       ^~~~~~~~~~~~~~
/home/yunshu/Studio/GitHub/miniob/src/observer/storage/persist/persist.cpp:288:4: 错误：no declaration matches ‘RC PersistHandler::seek(uint64_t)’
  288 | RC PersistHandler::seek(uint64_t offset)
      |    ^~~~~~~~~~~~~~
/home/yunshu/Studio/GitHub/miniob/src/observer/storage/persist/persist.h:60:6: 附注：备选是： ‘RC PersistHandler::seek(int)’
   60 |   RC seek(uint64_t offset);
      |      ^~~~
/home/yunshu/Studio/GitHub/miniob/src/observer/storage/persist/persist.h:26:7: 附注：‘class PersistHandler’ defined here
   26 | class PersistHandler
      |       ^~~~~~~~~~~~~~
make[2]: *** [src/observer/CMakeFiles/observer_static.dir/build.make:1224：src/observer/CMakeFiles/observer_static.dir/storage/prsist/persist.cpp.o] 错误 1
make[2]: *** 正在等待未完成的任务....
make[1]: *** [CMakeFiles/Makefile2:330：src/observer/CMakeFiles/observer_static.dir/all] 错误 2
make: *** [Makefile:146：all] 错误 2
```

### What problem were solved in this pull request?

Issue Number: close #xxx

Problem: build failed because the declaration of uint64_t could not be found.

### What is changed and how it works?

add `<stdint.h>`

### Other information
