### PR TITLE
style: add a rule to avoid formatting LOG_* macros

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,6 +20,8 @@ AllowShortLoopsOnASingleLine: false
 AlwaysBreakTemplateDeclarations: true
 # false表示函数实参要么都在同一行，要么都各自一行
 BinPackArguments: false
+# 避免格式化 LOG_* 宏
+WhitespaceSensitiveMacros: ['LOG_DEFAULT', 'LOG_PANIC', 'LOG_ERROR', 'LOG_WARN', 'LOG_INFO', 'LOG_DEBUG', 'LOG_TRACE']
 AlwaysBreakBeforeMultilineStrings: false
 BreakBeforeBinaryOperators: None
 BreakBeforeTernaryOperators: true


### PR DESCRIPTION
### What problem were solved in this pull request?

Issue Number: close https://github.com/oceanbase/miniob/issues/258

Problem:

### What is changed and how it works?

### Other information
