### PR TITLE
bugfix: fix get record failed when page_handler has inited

### DIFF
--- a/src/observer/storage/record/record_manager.cpp
+++ b/src/observer/storage/record/record_manager.cpp
@@ -82,8 +82,12 @@ RecordPageHandler::~RecordPageHandler() { cleanup(); }
 RC RecordPageHandler::init(DiskBufferPool &buffer_pool, PageNum page_num, bool readonly)
 {
   if (disk_buffer_pool_ != nullptr) {
-    LOG_WARN("Disk buffer pool has been opened for page_num %d.", page_num);
-    return RC::RECORD_OPENNED;
+    if (frame_->page_num() == page_num) {
+      LOG_WARN("Disk buffer pool has been opened for page_num %d.", page_num);
+      return RC::RECORD_OPENNED;
+    } else {
+      cleanup();
+    }
   }
 
   RC ret = RC::SUCCESS;
@@ -457,7 +461,7 @@ RC RecordFileHandler::get_record(RecordPageHandler &page_handler, const RID *rid
   }
 
   RC ret = page_handler.init(*disk_buffer_pool_, rid->page_num, readonly);
-  if (OB_FAIL(ret)) {
+  if (OB_FAIL(ret) && ret != RC::RECORD_OPENNED) {
     LOG_ERROR("Failed to init record page handler.page number=%d", rid->page_num);
     return ret;
   }


### PR DESCRIPTION
### What problem were solved in this pull request?

In the `next()` function of Operator, `record_handler_->get_record(record_page_handler_, &rid, readonly_, &current_record_)` may be invoked more than one time. In this case, `record_page_handler_` has inited, it will return `RC::RECORD_OPENNED`, and `get_record()` will be failed.

### What is changed and how it works?
When `page_handler.init()` return `RC::RECORD_OPENNED`, return `page_handler.get_record()` in `RecordFileHandler`.
