### PR TITLE
fix: not open child operator in ExplainPhysicalOperator

### DIFF
--- a/src/observer/sql/operator/explain_physical_operator.cpp
+++ b/src/observer/sql/operator/explain_physical_operator.cpp
@@ -21,6 +21,7 @@ using namespace std;
 RC ExplainPhysicalOperator::open(Trx *)
 {
   ASSERT(children_.size() == 1, "explain must has 1 child");
+  children_[0]->open(nullptr);
   return RC::SUCCESS;
 }
 

--- a/src/observer/sql/operator/explain_physical_operator.cpp
+++ b/src/observer/sql/operator/explain_physical_operator.cpp
@@ -21,17 +21,10 @@ using namespace std;
 RC ExplainPhysicalOperator::open(Trx *)
 {
   ASSERT(children_.size() == 1, "explain must has 1 child");
-  children_[0]->open(nullptr);
   return RC::SUCCESS;
 }
 
-RC ExplainPhysicalOperator::close()
-{
-  for (std::unique_ptr<PhysicalOperator> &child_oper : children_) {
-    child_oper->close();
-  }
-  return RC::SUCCESS;
-}
+RC ExplainPhysicalOperator::close() { return RC::SUCCESS; }
 
 RC ExplainPhysicalOperator::next()
 {
@@ -42,7 +35,7 @@ RC ExplainPhysicalOperator::next()
   stringstream ss;
   ss << "OPERATOR(NAME)\n";
 
-  int level = 0;
+  int               level = 0;
   std::vector<bool> ends;
   ends.push_back(true);
   const auto children_size = static_cast<int>(children_.size());
@@ -56,17 +49,14 @@ RC ExplainPhysicalOperator::next()
   physical_plan_ = ss.str();
 
   vector<Value> cells;
-  Value cell;
+  Value         cell;
   cell.set_string(physical_plan_.c_str());
   cells.emplace_back(cell);
   tuple_.set_cells(cells);
   return RC::SUCCESS;
 }
 
-Tuple *ExplainPhysicalOperator::current_tuple()
-{
-  return &tuple_;
-}
+Tuple *ExplainPhysicalOperator::current_tuple() { return &tuple_; }
 
 /**
  * 递归打印某个算子
@@ -108,7 +98,7 @@ void ExplainPhysicalOperator::to_string(
   ends[level + 1] = false;
 
   vector<std::unique_ptr<PhysicalOperator>> &children = oper->children();
-  const auto size = static_cast<int>(children.size());
+  const auto                                 size     = static_cast<int>(children.size());
   for (auto i = 0; i < size - 1; i++) {
     to_string(os, children[i].get(), level + 1, false /*last_child*/, ends);
   }


### PR DESCRIPTION
### What problem were solved in this pull request?

Problem: not open child operator in ExplainPhysicalOperator

### How to reproduce:

```
create table a (a int);
create index idx on a(a);
explain delete from a where a=1;
```

cause SegFault, because IndexScanPhysicalOperator not open

### What is changed and how it works?

Just add `children_[0]->open(nullptr);` in `ExplainPhysicalOperator::open`
