### PR TITLE
fix: do not close in ExplainPhysicalOperator

### DIFF
--- a/src/observer/sql/operator/explain_physical_operator.cpp
+++ b/src/observer/sql/operator/explain_physical_operator.cpp
@@ -26,9 +26,6 @@ RC ExplainPhysicalOperator::open(Trx *)
 
 RC ExplainPhysicalOperator::close()
 {
-  for (std::unique_ptr<PhysicalOperator> &child_oper : children_) {
-    child_oper->close();
-  }
   return RC::SUCCESS;
 }
 


### PR DESCRIPTION
### What problem were solved in this pull request?

Problem: do not close child operator in ExplainPhysicalOperator

### How to reproduce:

```
create table a (a int);
create index idx on a(a);
explain delete from a where a=1;
```

cause SegFault, because trying to close IndexScanPhysicalOperator, but not open

### What is changed and how it works?

Just do not close child oper in `ExplainPhysicalOperator::close`
