### PR TITLE
fix: overflow

### DIFF
--- a/deps/common/lang/comparator.cpp
+++ b/deps/common/lang/comparator.cpp
@@ -23,7 +23,13 @@ int compare_int(void *arg1, void *arg2)
 {
   int v1 = *(int *)arg1;
   int v2 = *(int *)arg2;
-  return v1 - v2;
+  if (v1 > v2) {
+    return 1;
+  } else if (v1 < v2) {
+    return -1;
+  } else {
+    return 0;
+  }
 }
 
 int compare_float(void *arg1, void *arg2)


### PR DESCRIPTION
### What problem were solved in this pull request?

Problem: compare_int uses subtraction to determine the size of two integers, which may cause integer overflow and return incorrect results.

### How to reproduce

When v1 is -2147483648 and v2 is 1, return 2147483647. Returned incorrect result due to integer overflow

### What is changed and how it works?

Use comparison operators instead of subtraction
