### PR TITLE
fix:修复了被open调用时，set_schema会重复添加数据的问题

### DIFF
--- a/src/observer/sql/expr/tuple.h
+++ b/src/observer/sql/expr/tuple.h
@@ -153,6 +153,9 @@ public:
   void set_schema(const Table *table, const std::vector<FieldMeta> *fields)
   {
     table_ = table;
+    // fix:在join当中会调用多次open来获取数据，而每一次open都会调用set_schema，
+    // 从而导致speces被重复添加，因此需要先clear掉
+    this->speces_.clear();
     this->speces_.reserve(fields->size());
     for (const FieldMeta &field : *fields) {
       speces_.push_back(new FieldExpr(table, &field));


### PR DESCRIPTION
### What problem were solved in this pull request?

Issue Number: close #311 

Problem: 在NLJ里面会遍历多次右表，就会调用很多次close和open，而open当中会调用set_schema，从而导致join的时候就会出来一个几十个field和value的tuple，后续的话会被select的字段给过滤掉，不影响正确性

### What is changed and how it works?
在set_schema当中每次先清空原本tuple当中的field即可。

### Other information
