### PR TITLE
fix:修复了set_schema当中会因为多次调用open而添加重复数据的问题

### DIFF
--- a/src/observer/sql/expr/tuple.h
+++ b/src/observer/sql/expr/tuple.h
@@ -153,6 +153,9 @@ public:
   void set_schema(const Table *table, const std::vector<FieldMeta> *fields)
   {
     table_ = table;
+    // fix:join当中会多次调用右表的open,open当中会调用set_scheme，从而导致tuple当中会存储
+    // 很多无意义的field和value，因此需要先clear掉
+    this->speces_.clear();
     this->speces_.reserve(fields->size());
     for (const FieldMeta &field : *fields) {
       speces_.push_back(new FieldExpr(table, &field));


### PR DESCRIPTION
### What problem were solved in this pull request?

Issue Number: close #xxx

Problem:NLJ里面会遍历多次右表，就会调用很多次open，在open当中就会调用set_schema，然后join的时候就会添加大量重复的field和value的tuple，后续的话会被select的字段给过滤掉，不影响正确性，但是进行了冗余存储

### What is changed and how it works?
在set_schema当中，每次先将原本的数据clear掉

### Other information
