### PR TITLE
fix:修复了mvcc模式下无法正确删除由当前事务插入的记录

### DIFF
--- a/src/observer/storage/trx/mvcc_trx.cpp
+++ b/src/observer/storage/trx/mvcc_trx.cpp
@@ -12,14 +12,12 @@ See the Mulan PSL v2 for more details. */
 // Created by Wangyunlai on 2023/04/24.
 //
 
-#include <cstddef>
 #include <limits>
 #include "storage/trx/mvcc_trx.h"
 #include "storage/field/field.h"
 #include "storage/clog/clog.h"
 #include "storage/db/db.h"
 #include "storage/clog/clog.h"
-
 
 using namespace std;
 

--- a/src/observer/storage/trx/mvcc_trx.cpp
+++ b/src/observer/storage/trx/mvcc_trx.cpp
@@ -14,15 +14,12 @@ See the Mulan PSL v2 for more details. */
 
 #include <cstddef>
 #include <limits>
-#include <sys/_types/_int32_t.h>
-#include <utility>
-#include "common/log/log.h"
 #include "storage/trx/mvcc_trx.h"
 #include "storage/field/field.h"
 #include "storage/clog/clog.h"
 #include "storage/db/db.h"
 #include "storage/clog/clog.h"
-#include "storage/trx/trx.h"
+
 
 using namespace std;
 


### PR DESCRIPTION
### What problem were solved in this pull request?

Issue Number: close #314 
mvcc模式下无法正确删除当前事务插入的记录


### What is changed and how it works?
在trx.delete_record添加特判，如果是删除当前事务插入的记录，就直接调用delete_record,并且也不添加到operation_里面，同时清除operation里面的相关insert_operation,这样可以保证事务内、提交后、回滚后、都能正确执行，并且不影响垃圾回收

