### PR TITLE
add sysbench liscence

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -130,3 +130,22 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+========================================================================
+
+=============================== sysbench =============================
+-- Copyright (C) 2006-2017 Alexey Kopytov <akopytov@gmail.com>
+
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 2 of the License, or
+-- (at your option) any later version.
+
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+
+-- You should have received a copy of the GNU General Public License
+-- along with this program; if not, write to the Free Software
+-- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA

--- a/test/sysbench/miniob_common.lua
+++ b/test/sysbench/miniob_common.lua
@@ -1,12 +1,18 @@
--- Copyright (c) 2023 OceanBase and/or its affiliates. All rights reserved.
--- miniob is licensed under Mulan PSL v2.
--- You can use this software according to the terms and conditions of the Mulan PSL v2.
--- You may obtain a copy of Mulan PSL v2 at:
---         http://license.coscl.org.cn/MulanPSL2
--- THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
--- EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
--- MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
--- See the Mulan PSL v2 for more details.
+-- Copyright (C) 2006-2018 Alexey Kopytov <akopytov@gmail.com>
+
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 2 of the License, or
+-- (at your option) any later version.
+
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+
+-- You should have received a copy of the GNU General Public License
+-- along with this program; if not, write to the Free Software
+-- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 -- -----------------------------------------------------------------------------
 -- Common code for OLTP benchmarks.

--- a/test/sysbench/miniob_insert.lua
+++ b/test/sysbench/miniob_insert.lua
@@ -1,13 +1,19 @@
 #!/usr/bin/env sysbench
--- Copyright (c) 2023 OceanBase and/or its affiliates. All rights reserved.
--- miniob is licensed under Mulan PSL v2.
--- You can use this software according to the terms and conditions of the Mulan PSL v2.
--- You may obtain a copy of Mulan PSL v2 at:
---         http://license.coscl.org.cn/MulanPSL2
--- THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
--- EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
--- MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
--- See the Mulan PSL v2 for more details.
+-- Copyright (C) 2006-2017 Alexey Kopytov <akopytov@gmail.com>
+
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 2 of the License, or
+-- (at your option) any later version.
+
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+
+-- You should have received a copy of the GNU General Public License
+-- along with this program; if not, write to the Free Software
+-- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 -- ----------------------------------------------------------------------
 -- Insert-Only OLTP benchmark


### PR DESCRIPTION
### What problem were solved in this pull request?

Problem:
miniob uses sysbench as the concurrency testing tool but there is no sysbench liscence

### What is changed and how it works?
add sysbench liscence
