### PR TITLE
Update link in introduction of dev-env doc

### DIFF
--- a/docs/src/dev-env/introduction.md
+++ b/docs/src/dev-env/introduction.md
@@ -6,6 +6,6 @@ MiniOB 当前可以在Linux/MacOS上编译，所以开发环境最好是Linux或
 - [开发环境搭建(本地调试, 适用 Linux 和 Mac)](how_to_dev_miniob_by_vscode.md)
 - [开发环境搭建(远程调试, 适用于 Window, Linux 和 Mac)](how_to_dev_in_docker_container_by_vscode.md)
 - [Windows 使用Docker开发MiniOB](how_to_dev_miniob_by_docker_on_windows.md)
-- [手把手教你在windows上用docker和vscode配置环境](./dev-env/how_to_dev_in_docker_container_by_vscode_on_windows.md)
+- [手把手教你在windows上用docker和vscode配置环境](how_to_dev_in_docker_container_by_vscode_on_windows.md)
 - [使用Docker开发MiniOB](how-to-dev-using-docker.md)
-- [MiniOB 调试](./dev-env/miniob-how-to-debug.md)
+- [MiniOB 调试](miniob-how-to-debug.md)


### PR DESCRIPTION
### What problem were solved in this pull request?

Problem: In the introduction document of dev-env, the links of `手把手教你在windows上用docker和vscode配置环境` and `MiniOB 调试` are not correct.

### What is changed and how it works?

Correct the link and it works now.