### PR TITLE
bug fix of bitmap find next bit(#335)

### DIFF
--- a/deps/common/lang/bitmap.cpp
+++ b/deps/common/lang/bitmap.cpp
@@ -77,9 +77,8 @@ int Bitmap::next_unsetted_bit(int start)
         ret = iter * 8 + index_in_byte;
         break;
       }
-
-      start_in_byte = 0;
     }
+    start_in_byte = 0;
   }
 
   if (ret >= size_) {

--- a/deps/common/lang/bitmap.cpp
+++ b/deps/common/lang/bitmap.cpp
@@ -99,9 +99,8 @@ int Bitmap::next_setted_bit(int start)
         ret = iter * 8 + index_in_byte;
         break;
       }
-
-      start_in_byte = 0;
     }
+    start_in_byte = 0;
   }
 
   if (ret >= size_) {


### PR DESCRIPTION
### What problem were solved in this pull request?

Issue Number: close #335 

Problem: the first set/unset bit was not found correctly.

### What is changed and how it works?
now the first set/unset bit could be found correctly.

### Other information
