### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ CMAKE_COMMAND="cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 --log-level=STATUS"
 
 ALL_ARGS=("$@")
 BUILD_ARGS=()
-MAKE_ARGS=(-j $CPU_CORES)
+MAKE_ARGS=()
 MAKE=make
 
 echo "$0 ${ALL_ARGS[@]}"
@@ -21,10 +21,11 @@ function usage
   echo "./build.sh init # install dependence"
   echo "./build.sh clean"
   echo "./build.sh [BuildType] [--make [MakeOptions]]"
+  echo "./build.sh [BuildType] [[MakeOptions]]"
   echo ""
   echo "OPTIONS:"
   echo "BuildType => debug(default), release"
-  echo "MakeOptions => Options to make command, default: -j N"
+  echo "MakeOptions => Options to make command, default: -jN"
 
   echo ""
   echo "Examples:"
@@ -42,6 +43,9 @@ function parse_args
     if [[ "$arg" == "--make" ]]
     then
       make_start=true
+    elif [[ "$arg" =~ ^-j[0-9]+ ]]
+    then
+      MAKE_ARGS+=("$arg")
     elif [[ $make_start == false ]]
     then
       BUILD_ARGS+=("$arg")


### PR DESCRIPTION
去掉默认自动检测当前机器上CPU的个数来决定编译并发数量，改由自己决策。

### What problem were solved in this pull request?

Issue Number: close #330

Problem:收到多名同学反馈编译执行buidl.sh卡死。build.sh中会自动检测当前机器上CPU的个数来决定编译并发数量，但是很多同学的机器内存与CPU并不匹配，会导致编译卡死。

### What is changed and how it works?
> change `MAKE_ARGS=(-j $CPU_CORES)` to `MAKE_ARGS=()`
> add `echo "./build.sh [BuildType] [[MakeOptions]]"` in `function usage`
> add `elif [[ "$arg" =~ ^-j[0-9]+ ]]
    then
      MAKE_ARGS+=("$arg")`  in `function parse_args`
* 去掉并发编译，使用者各取所需，在执行build.sh时直接使用 -jN 参数自行选择并行度。
### Other information
