### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ CMAKE_COMMAND="cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 --log-level=STATUS"
 
 ALL_ARGS=("$@")
 BUILD_ARGS=()
-MAKE_ARGS=(-j $CPU_CORES)
+MAKE_ARGS=()
 MAKE=make
 
 echo "$0 ${ALL_ARGS[@]}"


### PR DESCRIPTION
去掉默认自动检测当前机器上CPU的个数来决定编译并发数量，改由自己决策。 
 ### What problem were solved in this pull request?
 Issue Number:  #303
 
 Problem:收到多名同学反馈编译执行buidl.sh卡死。build.sh中会自动检测当前机器上CPU的个数来决定编译并发数量，但是很多同学的机器内存与CPU并不匹配，会导致编译卡死。
 
 ### What is changed and how it works?
> 将此处改成`MAKE_ARGS=()`
>
>https://github.com/oceanbase/miniob/blob/f42235649b7d3860aaecc08265bb801b12dd7ef3/build.sh#L12


 * 去掉并发编译，使用者各取所需，在执行build.sh时直接使用 -jN 参数自行选择并行度。

 ### Other information

