### PR TITLE
remove features in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,3 @@
 {
-  "image": "oceanbase/miniob",
-  "features": {
-    "ghcr.io/wxw-matt/devcontainer-features/apt:latest": {
-      "packages": "cmake flex bison texinfo libreadline-dev"
-    }
-  }
+  "image": "oceanbase/miniob"
 }


### PR DESCRIPTION
### What problem were solved in this pull request?

Problem:
oceanbase/miniob 镜像中已经把需要的依赖都加上了，如果还需要其它依赖，应该调整miniob镜像。
而且在国内安装devcontainer features中描述的组件，特别慢。

### What is changed and how it works?
删除devcontainer文件中features相关内容
