### PR TITLE
fix: add missing header files

### DIFF
--- a/deps/common/lang/serializer.h
+++ b/deps/common/lang/serializer.h
@@ -16,6 +16,7 @@ See the Mulan PSL v2 for more details. */
 
 #include <vector>
 #include <span>
+#include <cstdint>
 
 namespace common {
 

--- a/src/observer/storage/buffer/double_write_buffer.cpp
+++ b/src/observer/storage/buffer/double_write_buffer.cpp
@@ -14,6 +14,7 @@ See the Mulan PSL v2 for more details. */
 #include <fcntl.h>
 
 #include <mutex>
+#include <algorithm>
 
 #include "storage/buffer/double_write_buffer.h"
 #include "storage/buffer/disk_buffer_pool.h"


### PR DESCRIPTION
### What problem were solved in this pull request?

Problem:

Failed to compile `deps/common/lang/serializer` and `src/observer/storage/buffer/double_write_buffer`

Here are my build log:

1. In `serializer`

```
/home/sisabyss/git/miniob/deps/common/lang/serializer.h:44:3: 错误：‘int64_t’不是一个类型名
   44 |   int64_t size() const { return buffer_.size(); }
      |   ^~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.h:19:1: 附注：‘int64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   18 | #include <span>
  +++ |+#include <cstdint>
   19 | // #include <cstdint>
/home/sisabyss/git/miniob/deps/common/lang/serializer.h:50:19: 错误：‘int32_t’未声明
   50 |   int write_int32(int32_t value);
      |                   ^~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.h:52:19: 错误：‘int64_t’未声明
   52 |   int write_int64(int64_t value);
      |                   ^~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.h:77:3: 错误：‘int64_t’不是一个类型名
   77 |   int64_t size() const { return buffer_.size(); }
      |   ^~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.h:77:3: 附注：‘int64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sisabyss/git/miniob/deps/common/lang/serializer.h:80:3: 错误：‘int64_t’不是一个类型名
   80 |   int64_t remain() const { return buffer_.size() - position_; }
      |   ^~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.h:80:3: 附注：‘int64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sisabyss/git/miniob/deps/common/lang/serializer.h:83:18: 错误：‘int32_t’未声明
   83 |   int read_int32(int32_t &value);
      |                  ^~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.h:85:18: 错误：‘int64_t’未声明
   85 |   int read_int64(int64_t &value);
      |                  ^~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.h:89:3: 错误：‘int64_t’不是一个类型名
   89 |   int64_t               position_ = 0;  ///< 当前读取到的位置
      |   ^~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.h:89:3: 附注：‘int64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:28:5: 错误：‘int common::Serializer::write_int32’ is not a static data member of ‘class common::Serializer’
   28 | int Serializer::write_int32(int32_t value)
      |     ^~~~~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:28:29: 错误：‘int32_t’在此作用域中尚未声明
   28 | int Serializer::write_int32(int32_t value)
      |                             ^~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:18:1: 附注：‘int32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   17 | #include "common/lang/serializer.h"
  +++ |+#include <cstdint>
   18 | 
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:34:5: 错误：‘int common::Serializer::write_int64’ is not a static data member of ‘class common::Serializer’
   34 | int Serializer::write_int64(int64_t value)
      |     ^~~~~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:34:29: 错误：‘int64_t’在此作用域中尚未声明
   34 | int Serializer::write_int64(int64_t value)
      |                             ^~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:34:29: 附注：‘int64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp: In member function ‘int common::Deserializer::read(std::span<char>)’:
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:42:19: 错误：‘int64_t’不是一个类型名
   42 |   if (static_cast<int64_t>(data.size()) > remain()) {
      |                   ^~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:42:19: 附注：‘int64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:42:43: 错误：‘remain’在此作用域中尚未声明
   42 |   if (static_cast<int64_t>(data.size()) > remain()) {
      |                                           ^~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:46:40: 错误：‘position_’在此作用域中尚未声明
   46 |   memcpy(data.data(), buffer_.data() + position_, data.size());
      |                                        ^~~~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp: 在全局域：
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:51:5: 错误：‘int common::Deserializer::read_int32’ is not a static data member of ‘class common::Deserializer’
   51 | int Deserializer::read_int32(int32_t &value)
      |     ^~~~~~~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:51:30: 错误：‘int32_t’在此作用域中尚未声明
   51 | int Deserializer::read_int32(int32_t &value)
      |                              ^~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:51:30: 附注：‘int32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:51:39: 错误：‘value’在此作用域中尚未声明
   51 | int Deserializer::read_int32(int32_t &value)
      |                                       ^~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:57:5: 错误：‘int common::Deserializer::read_int64’ is not a static data member of ‘class common::Deserializer’
   57 | int Deserializer::read_int64(int64_t &value)
      |     ^~~~~~~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:57:30: 错误：‘int64_t’在此作用域中尚未声明
   57 | int Deserializer::read_int64(int64_t &value)
      |                              ^~~~~~~
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:57:30: 附注：‘int64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/sisabyss/git/miniob/deps/common/lang/serializer.cpp:57:39: 错误：‘value’在此作用域中尚未声明
   57 | int Deserializer::read_int64(int64_t &value)
      |                                       ^~~~~
make[2]: *** [deps/common/CMakeFiles/common.dir/build.make:160：deps/common/CMakeFiles/common.dir/lang/serializer.cpp.o] 错误 1
make[1]: *** [CMakeFiles/Makefile2:255：deps/common/CMakeFiles/common.dir/all] 错误 2
make: *** [Makefile:146：all] 错误 2
```

2. In `double_write_buffer`

```
/home/sisabyss/git/miniob/src/observer/storage/buffer/double_write_buffer.cpp: In member function ‘virtual RC DiskDoubleWriteBuffer::clear_pages(DiskBufferPool*)’:
/home/sisabyss/git/miniob/src/observer/storage/buffer/double_write_buffer.cpp:198:3: 错误：‘sort’ was not declared in this scope; did you mean ‘short’?
  198 |   sort(spec_pages.begin(), spec_pages.end(), [](DoubleWritePage *a, DoubleWritePage *b) {
      |   ^~~~
      |   short
/home/sisabyss/git/miniob/src/observer/storage/buffer/double_write_buffer.cpp:212:3: 错误：‘for_each’在此作用域中尚未声明
  212 |   for_each(spec_pages.begin(), spec_pages.end(), [](DoubleWritePage *dbl_page) { delete dbl_page; });
      |   ^~~~~~~~
make[2]: *** [src/observer/CMakeFiles/observer_static.dir/build.make:1126：src/observer/CMakeFiles/observer_static.dir/storage/buffer/double_write_buffer.cpp.o] 错误 1
make[1]: *** [CMakeFiles/Makefile2:334：src/observer/CMakeFiles/observer_static.dir/all] 错误 2
make: *** [Makefile:146：all] 错误 2
```

My GNU/GCC version:
```
使用内建 specs。
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/14.1.1/lto-wrapper
目标：x86_64-pc-linux-gnu
配置为：/build/gcc/src/gcc/configure --enable-languages=ada,c,c++,d,fortran,go,lto,m2,objc,obj-c++,rust --enable-bootstrap --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://gitlab.archlinux.org/archlinux/packaging/packages/gcc/-/issues --with-build-config=bootstrap-lto --with-linker-hash-style=gnu --with-system-zlib --enable-__cxa_atexit --enable-cet=auto --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-libstdcxx-backtrace --enable-link-serialization=1 --enable-linker-build-id --enable-lto --enable-multilib --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-werror
线程模型：posix
支持的 LTO 压缩算法：zlib zstd
gcc 版本 14.1.1 20240507 (GCC) 
```

### What is changed and how it works?

Add `<algorithm>` and `<cstdint>`

### Other information
