### PR TITLE
fix double write buffer recovery

### DIFF
--- a/src/observer/storage/buffer/double_write_buffer.cpp
+++ b/src/observer/storage/buffer/double_write_buffer.cpp
@@ -33,6 +33,7 @@ public:
 public:
   DoubleWritePageKey key;
   int32_t            page_index = -1; /// 页面在double write buffer文件中的页索引
+  bool               valid = true; /// 表示页面是否有效，在页面被删除时，需要同时标记磁盘上的值。
   Page               page;
 
   static const int32_t SIZE;
@@ -54,10 +55,6 @@ DiskDoubleWriteBuffer::DiskDoubleWriteBuffer(BufferPoolManager &bp_manager, int 
 DiskDoubleWriteBuffer::~DiskDoubleWriteBuffer()
 {
   flush_page();
-
-  for (auto &node : dblwr_pages_) {
-    delete node.second;
-  }
   close(file_desc_);
 }
 
@@ -87,6 +84,8 @@ RC DiskDoubleWriteBuffer::flush_page()
     if (rc != RC::SUCCESS) {
       return rc;
     }
+    pair.second->valid = false;
+    write_page_internal(pair.second);
     delete pair.second;
   }
 
@@ -165,6 +164,12 @@ RC DiskDoubleWriteBuffer::write_page_internal(DoubleWritePage *page)
 RC DiskDoubleWriteBuffer::write_page(DoubleWritePage *dblwr_page)
 {
   DiskBufferPool *disk_buffer = nullptr;
+  // skip invalid page
+  if (!dblwr_page->valid) {
+    LOG_TRACE("double write buffer write page invalid. buffer_pool_id:%d,page_num:%d,lsn=%d",
+              dblwr_page->key.buffer_pool_id, dblwr_page->key.page_num, dblwr_page->page.lsn);
+    return RC::SUCCESS;
+  }
   RC rc = bp_manager_.get_buffer_pool(dblwr_page->key.buffer_pool_id, disk_buffer);
   ASSERT(OB_SUCC(rc) && disk_buffer != nullptr, "failed to get disk buffer pool of %d", dblwr_page->key.buffer_pool_id);
 
@@ -221,6 +226,8 @@ RC DiskDoubleWriteBuffer::clear_pages(DiskBufferPool *buffer_pool)
                buffer_pool->filename(), dbl_page->key.page_num, strrc(rc));
       break;
     }
+    dbl_page->valid = false;
+    write_page_internal(dbl_page);
   }
 
   for_each(spec_pages.begin(), spec_pages.end(), [](DoubleWritePage *dbl_page) { delete dbl_page; });


### PR DESCRIPTION
### What problem were solved in this pull request?
when clean DiskDoubleWriteBuffer::dblwr_pages_, it also need to mark the disk page invalid.

Issue Number: close #xxx

Problem:

### What is changed and how it works?

### Other information
