### PR TITLE
feat: support system base on musl libc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ OPTION(ENABLE_NOPIE "Enable no pie" OFF)
 OPTION(CONCURRENCY "Support concurrency operations" OFF)
 OPTION(STATIC_STDLIB "Link std library static or dynamic, such as libgcc, libstdc++, libasan" OFF)
 OPTION(USE_SIMD "Use SIMD" OFF)
+OPTION(USE_MUSL_LIBC "Use musl libc" OFF)
 
 MESSAGE(STATUS "HOME dir: $ENV{HOME}")
 #SET(ENV{变量名} 值)
@@ -79,6 +80,15 @@ MESSAGE(STATUS "CMAKE_CXX_COMPILER_ID is " ${CMAKE_CXX_COMPILER_ID})
 IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND ${STATIC_STDLIB})
     ADD_LINK_OPTIONS(-static-libgcc -static-libstdc++)
 ENDIF()
+
+IF(USE_MUSL_LIBC)
+    ADD_DEFINITIONS(-D__MUSL__)
+    MESSAGE(STATUS "musl libc use pthread in default")
+    SET(CMAKE_THREAD_LIBS_INIT "-lpthread")
+
+    MESSAGE(AUTHOR_WARNING "Sanitizer and musl libc not support each other for now")
+    SET(ENABLE_ASAN OFF)
+ENDIF(USE_MUSL_LIBC)
 
 IF (ENABLE_ASAN)
     MESSAGE(STATUS "Instrumenting with Address Sanitizer")

--- a/build.sh
+++ b/build.sh
@@ -111,6 +111,17 @@ function do_init
   cd $current_dir
 }
 
+function do_musl_init
+{
+  git submodule add https://github.com/ronchaine/libexecinfo deps/3rd/libexecinfo || return
+  current_dir=$PWD
+
+  MAKE_COMMAND="make --silent"
+  cd ${TOPDIR}/deps/3rd/libexecinfo && \
+    make install && \
+    make clean && rm ${TOPDIR}/deps/3rd/libexecinfo/libexecinfo.so.*
+}
+
 function prepare_build_dir
 {
   TYPE=$1
@@ -160,6 +171,9 @@ function main
       ;;
     init)
       do_init
+      ;;
+    musl)
+      do_musl_init
       ;;
     clean)
       do_clean

--- a/build.sh
+++ b/build.sh
@@ -113,13 +113,14 @@ function do_init
 
 function do_musl_init
 {
-  git submodule add https://github.com/ronchaine/libexecinfo deps/3rd/libexecinfo || return
+  git clone https://github.com/ronchaine/libexecinfo deps/3rd/libexecinfo || return
   current_dir=$PWD
 
   MAKE_COMMAND="make --silent"
   cd ${TOPDIR}/deps/3rd/libexecinfo && \
-    make install && \
-    make clean && rm ${TOPDIR}/deps/3rd/libexecinfo/libexecinfo.so.*
+    ${MAKE_COMMAND} install && \
+    ${MAKE_COMMAND} clean && rm ${TOPDIR}/deps/3rd/libexecinfo/libexecinfo.so.* && \
+    cd ${current_dir}
 }
 
 function prepare_build_dir

--- a/deps/common/CMakeLists.txt
+++ b/deps/common/CMakeLists.txt
@@ -9,6 +9,12 @@ FILE(GLOB_RECURSE ALL_SRC  *.cpp)
 #STATIC，静态库
 ADD_LIBRARY(common STATIC ${ALL_SRC} )
 
+
+IF(USE_MUSL_LIBC)
+    MESSAGE(STATUS "musl libc need manually link libexecinfo")
+    TARGET_LINK_LIBRARIES(common execinfo)
+ENDIF(USE_MUSL_LIBC)
+
 # 编译静态库时，自动会把同名的动态库给删除， 因此需要临时设置一下
 SET_TARGET_PROPERTIES(common PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 

--- a/deps/common/os/process.cpp
+++ b/deps/common/os/process.cpp
@@ -26,7 +26,7 @@ See the Mulan PSL v2 for more details. */
 
 namespace common {
 
-#ifdef __MACH__
+#if defined(__MACH__) or defined(__MUSL__)
 #include <libgen.h>
 #endif
 

--- a/src/observer/net/buffered_writer.cpp
+++ b/src/observer/net/buffered_writer.cpp
@@ -13,7 +13,11 @@ See the Mulan PSL v2 for more details. */
 //
 
 #include <algorithm>
+#ifdef __MUSL__
+#include <errno.h>
+#else
 #include <sys/errno.h>
+#endif
 #include <unistd.h>
 
 #include "net/buffered_writer.h"

--- a/src/observer/net/ring_buffer.h
+++ b/src/observer/net/ring_buffer.h
@@ -14,6 +14,10 @@ See the Mulan PSL v2 for more details. */
 
 #pragma once
 
+#ifdef __MUSL__
+#include <cstdint>
+#endif
+
 #include "common/rc.h"
 #include "common/lang/vector.h"
 

--- a/src/observer/net/ring_buffer.h
+++ b/src/observer/net/ring_buffer.h
@@ -14,9 +14,7 @@ See the Mulan PSL v2 for more details. */
 
 #pragma once
 
-#ifdef __MUSL__
-#include <cstdint>
-#endif
+#include <stdint.h>
 
 #include "common/rc.h"
 #include "common/lang/vector.h"


### PR DESCRIPTION
### What problem were solved in this pull request?

Issue Number: close #453 

Problem: Compatibility issues when implementing miniob on system based on musl libc like alpine linux.

### What is changed and how it works?

Install libexecinfo as musl libc not support this feature.

``` bash
# `bash build.sh init` first
bash build.sh musl
```

Turn on support at miniob/CMakeLists.txt#L25. Then build the project.

``` bash
bash build.sh
```

### Other information

This fix initially aims for developing and building miniob in docker containers using alpine linux.

NO Address Sanitizer Support in This PR.
