### PR TITLE
fix bug about comparing key in ob_compaction_test

### DIFF
--- a/unittest/oblsm/ob_compaction_test.cpp
+++ b/unittest/oblsm/ob_compaction_test.cpp
@@ -59,8 +59,8 @@ bool check_compaction(ObLsm* lsm)
     for (const auto& sstable : level_i) {
       key_ranges.push_back(make_pair(sstable->first_key(), sstable->last_key()));
     }
-    std::sort(key_ranges.begin(), key_ranges.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
     ObInternalKeyComparator comp;
+    std::sort(key_ranges.begin(), key_ranges.end(), [&](const auto& a, const auto& b) { return comp.compare(a.first, b.first) < 0; });
     for (size_t j = 1; j < key_ranges.size(); ++j) {
       if (comp.compare(key_ranges[j].first, key_ranges[j-1].second) < 0) {
         return false;


### PR DESCRIPTION

### Problem:

In MiniOB, a `key` consists of an `internal key` followed by a `seq` component. When checking for overlapping keys in a sorted run, we should sort and compare based on the `internal key` only. This is typically done by using the `internal key` as the sorting index and then comparing the last key of the previous SSTable with the first key of the current one.

However, if the full `key` (including `seq`) is used as the sorting index, the `seq` component will incorrectly influence the result of the overlap check, potentially leading to false negatives or positives.

### What is changed and how it works?

This PR replaces direct string comparison with the `obInternalKeyComparator` to sort and compare keys correctly, ensuring that only the `internal key` is considered during overlap checks.

### Other information
