### PR TITLE
fix potential overflow by casting one operand to lager integer type

### DIFF
--- a/src/observer/storage/index/bplus_tree.cpp
+++ b/src/observer/storage/index/bplus_tree.cpp
@@ -281,7 +281,7 @@ RC LeafIndexNodeHandler::move_half_to(LeafIndexNodeHandler &other)
 
   other.append(__item_at(move_index), move_item_num);
 
-  RC rc = mtr_.logger().node_remove_items(*this, move_index, span<const char>(__item_at(move_index), move_item_num * item_size()), move_item_num);
+  RC rc = mtr_.logger().node_remove_items(*this, move_index, span<const char>(__item_at(move_index), static_cast<long>(move_item_num) * item_size()), move_item_num);
   if (OB_FAIL(rc)) {
     LOG_WARN("failed to log shrink leaf node. rc=%s", strrc(rc));
     return rc;


### PR DESCRIPTION
### What problem were solved in this pull request?

Issue Number: close #xxx
#534

Problem:
Fix code scanning alert - Multiplication result converted to larger type #534

### What is changed and how it works?
Basically just casted one of the operand to 'long'. I wasn't sure if it was meant to be an unsigned type for example size_t and that's why I stuck to long.

### Other information
