### PR TITLE
fix the calculation of BPFileHeader::MAX_PAGE_NUM and BP_PAGE_DATA_SIZE

### DIFF
--- a/src/observer/storage/buffer/disk_buffer_pool.h
+++ b/src/observer/storage/buffer/disk_buffer_pool.h
@@ -71,7 +71,8 @@ struct BPFileHeader
   /**
    * 能够分配的最大的页面个数，即bitmap的字节数 乘以8
    */
-  static const int MAX_PAGE_NUM = (BP_PAGE_DATA_SIZE - sizeof(page_count) - sizeof(allocated_pages)) * 8;
+  static const int MAX_PAGE_NUM =
+      (BP_PAGE_DATA_SIZE - sizeof(buffer_pool_id) - sizeof(page_count) - sizeof(allocated_pages)) * 8;
 
   string to_string() const;
 };

--- a/src/observer/storage/buffer/page.h
+++ b/src/observer/storage/buffer/page.h
@@ -24,7 +24,7 @@ static constexpr PageNum BP_INVALID_PAGE_NUM = -1;
 static constexpr PageNum BP_HEADER_PAGE = 0;
 
 static constexpr const int BP_PAGE_SIZE      = (1 << 13);
-static constexpr const int BP_PAGE_DATA_SIZE = (BP_PAGE_SIZE - sizeof(PageNum) - sizeof(LSN) - sizeof(CheckSum));
+static constexpr const int BP_PAGE_DATA_SIZE = (BP_PAGE_SIZE - sizeof(LSN) - sizeof(CheckSum));
 
 /**
  * @brief 表示一个页面，可能放在内存或磁盘上


### PR DESCRIPTION
### What problem were solved in this pull request?

Issue Number: close #563

Problem:

### What is changed and how it works?

This PR addresses two inconsistencies in the buffer pool page layout calculations:

1. Fix `MAX_PAGE_NUM` Calculation in `BPFileHeader`

From: 
```cpp
static const int MAX_PAGE_NUM = (BP_PAGE_DATA_SIZE - sizeof(page_count) - sizeof(allocated_pages)) * 8;
```
To:
```cpp
static const int MAX_PAGE_NUM = (BP_PAGE_DATA_SIZE - sizeof(buffer_pool_id) - sizeof(page_count) - sizeof(allocated_pages)) * 8;
```

2. Fix `BP_PAGE_DATA_SIZE` in `page.h`

From: 
```cpp
static constexpr const int BP_PAGE_DATA_SIZE = (BP_PAGE_SIZE - sizeof(PageNum) - sizeof(LSN) - sizeof(CheckSum));
```
To:
```cpp
static constexpr const int BP_PAGE_DATA_SIZE = (BP_PAGE_SIZE - sizeof(LSN) - sizeof(CheckSum));
```

