### PR TITLE
Fix `BinaryIterator::operator-=` to pass compile in clang20

### DIFF
--- a/src/common/lang/lower_bound.h
+++ b/src/common/lang/lower_bound.h
@@ -106,7 +106,7 @@ public:
     data_ += (item_num_ * n);
     return *this;
   }
-  BinaryIterator &operator-=(int n) { return this->operator+(-n); }
+  BinaryIterator &operator-=(int n) { return this->operator+=(-n); }
   BinaryIterator &operator++() { return this->operator+=(1); }
   BinaryIterator  operator++(int)
   {


### PR DESCRIPTION
### What problem were solved in this pull request?

Issue Number: close #577

Problem: Compile failed with clang20

### What is changed and how it works?

fix `BinaryIterator::operator-=`

### Other information
