### PR TITLE
fix: semantic conflict of reset_data.

### DIFF
--- a/src/observer/storage/common/column.cpp
+++ b/src/observer/storage/common/column.cpp
@@ -131,6 +131,8 @@ RC Column::append_value(const Value &value)
 
   size_t total_bytes = std::min(value.length(), attr_len_);
   memcpy(data_ + count_ * attr_len_, value.data(), total_bytes);
+  if (total_bytes < attr_len_)
+    data_[count_ * attr_len_ + total_bytes] = 0;
 
   count_ += 1;
   return RC::SUCCESS;

--- a/src/observer/storage/common/column.h
+++ b/src/observer/storage/common/column.h
@@ -108,6 +108,7 @@ public:
   void reset_data()
   {
     count_         = 0;
+    memset(data_, 0, capacity_ * attr_len_);
     vector_buffer_ = nullptr;
   }
 

--- a/src/observer/storage/common/column.h
+++ b/src/observer/storage/common/column.h
@@ -108,7 +108,6 @@ public:
   void reset_data()
   {
     count_         = 0;
-    memset(data_, 0, capacity_ * attr_len_);
     vector_buffer_ = nullptr;
   }
 


### PR DESCRIPTION
reset_data() only reset the count, but not the data. When processing the string-like value, the previous data will be cached, and they may interfere with the new value. So reset the data after the count in reset_data().

### What problem were solved in this pull request?

Problem:

After calling reset_data() of Column with string type, call append_value() with another Value(). As long as the attr_len_ > Value.size(), the previous data will be retained, and they may interfere with the newly one, as the reset_data() does not clear the actual data inside.

For example:
id
ida
idb

After calling reset_data() and then call append_value() with actual string "a", the column will be as follows:
ad(the char 'c' retains.)
(the following are invalid.)

### What is changed and how it works?

reset_data() will clear the inside data actually, not only reset the count.

### Other information
