### PR TITLE
Fix memory leak of token when bison failed to parse SQL

### DIFF
--- a/src/observer/sql/parser/yacc_sql.y
+++ b/src/observer/sql/parser/yacc_sql.y
@@ -139,6 +139,18 @@ UnboundAggregateExpr *create_aggregate_expression(const char *aggregate_name,
   float                                      floats;
 }
 
+%destructor { delete $$; } <condition>
+%destructor { delete $$; } <value>
+%destructor { delete $$; } <rel_attr>
+%destructor { delete $$; } <attr_infos>
+%destructor { delete $$; } <expression>
+%destructor { delete $$; } <expression_list>
+%destructor { delete $$; } <value_list>
+%destructor { delete $$; } <condition_list>
+// %destructor { delete $$; } <rel_attr_list>
+%destructor { delete $$; } <relation_list>
+%destructor { delete $$; } <key_list>
+
 %token <number> NUMBER
 %token <floats> FLOAT
 %token <cstring> ID


### PR DESCRIPTION
### What problem were solved in this pull request?
When bison fails to parse SQL, memory leaks may occur,  such as 
select * from t where id><1;
<img width="1009" height="322" alt="memory leak" src="https://github.com/user-attachments/assets/3ea7974b-c881-4672-8437-dbaea404776f" />

Issue Number: close #xxx

Problem:

### What is changed and how it works?
In yacc_sql.y, use %destructor to specify the memory release action that needs to be called when parsing fails for the token, in order to prevent memory leaks that may occur in the event of an error.

### Other information
