### PR TITLE
Fix ArithmeticExpr.get_column in unit_test

### DIFF
--- a/src/observer/sql/expr/expression.cpp
+++ b/src/observer/sql/expr/expression.cpp
@@ -67,7 +67,7 @@ RC ValueExpr::get_value(const Tuple &tuple, Value &value) const
 
 RC ValueExpr::get_column(Chunk &chunk, Column &column)
 {
-  column.init(value_, std::max(chunk.rows(), 1));
+  column.init(value_, chunk.rows());
   return RC::SUCCESS;
 }
 

--- a/unittest/observer/expression_test.cpp
+++ b/unittest/observer/expression_test.cpp
@@ -147,6 +147,11 @@ TEST(ArithmeticExpr, get_column)
     Value float_value1((float)1.1);
     Value float_value2((float)2.2);
     Chunk chunk;
+    std::unique_ptr<Column> column_tmp = std::make_unique<Column>(AttrType::INTS, sizeof(int), 1);
+    char data[sizeof(int)];
+    memcpy(data, &int_value1, sizeof(int));
+    column_tmp->append_one(data);
+    chunk.add_column(std::move(column_tmp), 0);
 
     Value int_result;
     Value float_result;


### PR DESCRIPTION
### What problem were solved in this pull request?
In unit_test, the use of empty chunks in the ArithmeticExpr.get_column test resulted in no calculation results. Previously, the ValueExpr was modified to return at least one constant value, but it was found to be problematic. This time, the test case will be directly modified.

Issue Number: close #xxx

Problem:

### What is changed and how it works?

### Other information
