### PR TITLE
fix type mismatch in getFileSize function signature and implementation

### DIFF
--- a/src/common/io/io.h
+++ b/src/common/io/io.h
@@ -55,7 +55,7 @@ int touch(const string &fileName);
 /**
  * get file size
  */
-int getFileSize(const char *filePath, uint64_t &fileLen);
+int getFileSize(const char *filePath, int64_t &fileLen);
 
 /**
  * @brief 一次性写入所有指定数据


### PR DESCRIPTION
### What problem were solved in this pull request?

Issue Number: close #xxx

Problem:

### What is changed and how it works?

Fixed type mismatch in getFileSize by unifying the use of int64_t in both declaration and implementation.

### Other information
