### PR TITLE
Fix libevent, jsoncpp compilation on mac shows that cmake version is too high

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,10 @@ function prepare_build_dir
 function do_init
 {
   git submodule update --init || return
+  git -C "deps/3rd/libevent" checkout 112421c8fa4840acd73502f2ab6a674fc025de37 || return
+  # git submodule update --remote "deps/3rd/libevent" || return
+  git -C "deps/3rd/jsoncpp" checkout 1.9.6 || return
+
   current_dir=$PWD
 
   MAKE_COMMAND="make --silent"


### PR DESCRIPTION
Fix libevent, jsoncpp compilation on mac shows that cmake version is too high.

### What problem were solved in this pull request?
<img width="1112" height="322" alt="libevent fail" src="https://github.com/user-attachments/assets/c2f72f4a-ff61-41ff-afb2-d11870c918cf" />
Fix libevent, jsoncpp compilation on mac shows that cmake version is too high.
