### PR TITLE
[BUGFIX] fixed multiplication promotion to larger type in span size

### DIFF
--- a/src/observer/storage/index/bplus_tree.cpp
+++ b/src/observer/storage/index/bplus_tree.cpp
@@ -630,7 +630,7 @@ RC InternalIndexNodeHandler::move_last_to_front(InternalIndexNodeHandler &other)
 
 RC InternalIndexNodeHandler::insert_items(int index, const char *items, int num)
 {
-  RC rc = mtr_.logger().node_insert_items(*this, index, span<const char>(items, item_size() * num), num);
+  RC rc = mtr_.logger().node_insert_items(*this, index, span<const char>(items, static_cast<size_t>(item_size()) * static_cast<size_t>(num)), num);
   if (OB_FAIL(rc)) {
     LOG_WARN("failed to log insert item. rc=%s", strrc(rc));
     return rc;


### PR DESCRIPTION
### What problem was solved in this pull request?

Issue Number: Close #572

**Problem:**
Static analysis (codescan) flagged a potential issue where the result of a multiplication operation (`item_size() * num`) is implicitly converted to a larger type. This may lead to unexpected behavior or data loss on certain compilers or platforms due to integer overflow.

### What is changed and how it works?

**Changes:**
- Explicitly cast the multiplication result to the correct target type before passing it to `span<const char>()`.
- Ensures type safety and avoids potential overflow or truncation.

**Before:**
```cpp
span<const char>(items, item_size() * num)
```
**After:**
```cpp
span<const char>(items, static_cast<size_t>(item_size()) * num)
```
This ensures that the result of the multiplication is treated as a size_t, which is the expected type.