### PR TITLE
Fix libevent, jsoncpp compilation on mac shows that cmake version is too high

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,9 @@ function prepare_build_dir
 function do_init
 {
   git submodule update --init || return
+  git -C "deps/3rd/libevent" checkout 112421c8fa4840acd73502f2ab6a674fc025de37 || return
+  # git submodule update --remote "deps/3rd/libevent" || return
+  git -C "deps/3rd/jsoncpp" checkout 1.9.6 || return
   current_dir=$PWD
 
   MAKE_COMMAND="make --silent"


### PR DESCRIPTION
### What problem were solved in this pull request?
Fix libevent, jsoncpp compilation on mac shows that cmake version is too high.
<img width="789" height="184" alt="libevent fail" src="https://github.com/user-attachments/assets/1a1e4a78-fb92-4e98-a58e-7a7094f8d0ab" />


Issue Number: close #xxx

Problem:

### What is changed and how it works?

### Other information
