### PR TITLE
fix: remove duplicate library linking warnings on MacOS

### DIFF
--- a/src/observer/CMakeLists.txt
+++ b/src/observer/CMakeLists.txt
@@ -32,7 +32,7 @@ SET(LIBEVENT_STATIC_LINK TRUE)
 FIND_PACKAGE(Libevent CONFIG REQUIRED)
 FIND_PACKAGE(jsoncpp CONFIG REQUIRED)
 
-SET(LIBRARIES common pthread dl libevent::core libevent::pthreads JsonCpp::JsonCpp)
+SET(LIBRARIES common pthread dl libevent::core libevent::pthreads)
 
 # 指定目标文件位置
 SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)


### PR DESCRIPTION
### What problem were solved in this pull request?
When building under MacOS environment, there were build warnings about duplicate library linking:
ld: warning: ignoring duplicate libraries: './deps/3rd/usr/local/lib/libjsoncpp.a'

Issue Number: close #xxx

Problem:

### What is changed and how it works?

### Other information
This fix only affects the build process and does not change any runtime behavior
The changes are specific to MacOS environment but are safe for other platforms