### PR TITLE
fix(docs): math formulas cannot be displayed normally

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -73,13 +73,6 @@ nav:
     - blog/introduction.md
     - blog/1.md
 
-markdown_extensions:
-  - pymdownx.highlight:
-      anchor_linenums: true
-  - pymdownx.inlinehilite
-  - pymdownx.snippets
-  - pymdownx.superfences
-
 theme:
   name: material
   language: zh
@@ -132,6 +125,11 @@ extra:
       link: https://join.slack.com/t/oceanbase/shared_invite/zt-1e25oz3ol-lJ6YNqPHaKwY_mhhioyEuw
 
 markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
   - toc:
       permalink: true
   - pymdownx.arithmatex:
@@ -140,5 +138,6 @@ markdown_extensions:
 
 extra_javascript:
     - ./assets/mathjax.js
-    - https://polyfill.io/v3/polyfill.min.js?features=es6
+    # - https://polyfill.io/v3/polyfill.min.js?features=es6
+    - https://polyfill.alicdn.com/v3/polyfill.min.js?features=es6
     - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION

### What problem were solved in this pull request?

Issue Number: close #xxx

Problem: math formulas cannot be displayed normally
<img width="1195" height="842" alt="image" src="https://github.com/user-attachments/assets/3be29e12-6bcc-4c22-beab-48547ab38386" />

Because `polyfill.io` is blocked

see: https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet/

### What is changed and how it works?

use alicdn

### Other information
