### PR TITLE
fix(build): support the latest version of gcc

### DIFF
--- a/src/observer/sql/optimizer/cascade/tasks/o_expr_task.cpp
+++ b/src/observer/sql/optimizer/cascade/tasks/o_expr_task.cpp
@@ -14,6 +14,7 @@ See the Mulan PSL v2 for more details. */
 #include "sql/optimizer/cascade/group_expr.h"
 #include "sql/optimizer/cascade/memo.h"
 #include "common/log/log.h"
+#include <algorithm>
 
 void OptimizeExpression::perform()
 {

--- a/src/observer/storage/buffer/double_write_buffer.cpp
+++ b/src/observer/storage/buffer/double_write_buffer.cpp
@@ -18,6 +18,7 @@ See the Mulan PSL v2 for more details. */
 #include "common/io/io.h"
 #include "common/log/log.h"
 #include "common/math/crc.h"
+#include <algorithm>
 
 using namespace common;
 

--- a/src/observer/storage/common/codec.h
+++ b/src/observer/storage/common/codec.h
@@ -18,6 +18,7 @@ See the Mulan PSL v2 for more details. */
 #include "common/sys/rc.h"
 #include "common/value.h"
 #include <cstring>
+#include <algorithm>
 
 using byte_t    = unsigned char;
 using bytes     = vector<byte_t>;


### PR DESCRIPTION
### What problem were solved in this pull request?

When compiling MiniOB with a newer version of GCC (I use 15.1.1), a series of compilation errors may occur. This is mainly because the new version of the compiler has stricter standards for header file inclusion and namespace usage.

Issue Number: close None

Problem:

Some source files use algorithm functions like `std::sort` or `std::for_each` but do not include the `<algorithm>` header file.

### What is changed and how it works?

Added `#include <algorithm>` in all C++ source files that use `std::sort` and `std::for_each`.

### Other information

Tests show that after applying these modifications, the project can be successfully compiled in the GCC 15.1.1 environment.
